### PR TITLE
fix: create axon dir instead of pulling code

### DIFF
--- a/deploy/deploy.yml
+++ b/deploy/deploy.yml
@@ -10,15 +10,20 @@
     MALLOC_CONF: "prof:true,lg_prof_interval:30"
   tasks:
   ###############################################################################################################
-    - name: Pull code
-      git:
-        repo: "{{ axon_repo }}"
-        dest: "{{ deploy_path }}"
-        version: "{{ axon_branch }}"
-        force: yes
-      become: yes
-      become_method: sudo
-      tags: 
+    - name: check monitor dir
+      stat:
+        path: "{{ deploy_path }}"
+      register: file_status
+      tags:
+        - deploy
+
+    - name: create monitor dir
+      file:
+        path: "{{ deploy_path }}"
+        state: directory
+      when:
+        file_status.stat.exists == False
+      tags:
         - deploy
 
 ###############################################################################################################


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
fix: create axon dir instead of pulling code

#### CI Switch

ci-runs-only: [Cargo Clippy, Code Format, Unit Tests]
